### PR TITLE
Add common area UI

### DIFF
--- a/pic-sure-hpds-ui-extension-archetype/src/main/resources/archetype-resources/src/main/webapp/picsureui/overrides/ontology.js
+++ b/pic-sure-hpds-ui-extension-archetype/src/main/resources/archetype-resources/src/main/webapp/picsureui/overrides/ontology.js
@@ -10,6 +10,17 @@ define([], function(){
 		 * A function that takes a PUI that is already split on forward slash and returns
 		 * the parent value for that PUI.
 		 */
-		extractParentFromPui : undefined
+		extractParentFromPui : undefined,
+		
+		/*
+		 * A function to perform the initial population of the data export tree
+		 */
+		loadAllConceptsDeferred : undefined,
+		
+		/*
+		 * A function to perform the inital population of the variant info columns
+		 */
+		loadAllInfoColumnsDeferred : undefined
+	
 	};
 });

--- a/pic-sure-hpds-ui-extension-archetype/src/main/resources/archetype-resources/src/main/webapp/picsureui/overrides/outputPanel.js
+++ b/pic-sure-hpds-ui-extension-archetype/src/main/resources/archetype-resources/src/main/webapp/picsureui/overrides/outputPanel.js
@@ -31,6 +31,11 @@ define(["jquery", "handlebars", "backbone"], function($, HBS, BB){
 		/*
 		 * If you want to show your customized error message, please override this
 		 */
-		outputErrorMessage: undefined
+		outputErrorMessage: undefined,
+		
+		/*
+		 * A function to make any necessary updates to the query before submitting
+		 */
+		updateConsentFilters : undefined
 	};
 });

--- a/pic-sure-hpds-ui/src/main/resources/settings.json
+++ b/pic-sure-hpds-ui/src/main/resources/settings.json
@@ -1,14 +1,14 @@
 {
-  "resources":[
-		{
-			"id" : "HPDS",
-			"name" : "HPDS",
-			"basePath" : "/picsure",
-			"findPath" : "/PIC-SURE/search"
-		}
-		],
-  "picSureResourceId":"",
-  "applicationIdForBaseQuery":"",
+  "resources": [
+    {
+      "id": "HPDS",
+      "name": "HPDS",
+      "basePath": "/picsure",
+      "findPath": "/PIC-SURE/search"
+    }
+  ],
+  "picSureResourceId": "",
+  "applicationIdForBaseQuery": "",
   "helpLink": "about:blank",
   "advancedSearchLink": ""
 }

--- a/pic-sure-hpds-ui/src/main/webapp/picsureui/filter/searchResults.js
+++ b/pic-sure-hpds-ui/src/main/webapp/picsureui/filter/searchResults.js
@@ -17,7 +17,7 @@ define(["jquery", "filter/searchResult", "handlebars", "text!filter/searchResult
 			if(settingsJson.categoryAliases && settingsJson.categoryAliases[key]){
                 return settingsJson.categoryAliases[key];
             } else {
-                return key;
+                return key.toLowerCase();
             }
 		}
 		var keys = _.keys(data);

--- a/pic-sure-hpds-ui/src/main/webapp/picsureui/overrides/outputPanel.js
+++ b/pic-sure-hpds-ui/src/main/webapp/picsureui/overrides/outputPanel.js
@@ -1,4 +1,4 @@
-define(["jquery", "handlebars", "backbone"], function($, HBS, BB){
+define(["jquery", "handlebars", "backbone", "picSure/resourceMeta", "picSure/queryCache"], function ($, HBS, BB, resourceMeta, queryCache) {
 	return {
 		/*
 		 * This should be a function that returns the name of a Handlebars partial
@@ -27,12 +27,46 @@ define(["jquery", "handlebars", "backbone"], function($, HBS, BB){
 		 * and dispatches it to the resources you choose, and handles registering
 		 * callbacks for the responses and error handling.
 		 */
-		update: undefined,
+		update: function (incomingQuery) {
+			this.model.set("totalPatients", 0);
+			
+			this.model.spinAll();
+			this.render();
+
+			_.each(resourceMeta, function (picsureInstance) {
+				// make a safe deep copy of the incoming query so we don't modify it
+				var query = JSON.parse(JSON.stringify(incomingQuery));
+
+				var dataCallback = function (result) {
+					if (result === undefined || result.status === "ERROR") {
+						this.model.get("resources")[picsureInstance.id].patientCount = 0;
+					} else {
+						var count = parseInt(result.data[0][0].patient_set_counts);
+						this.model.get("resources")[picsureInstance.id].queryRan = true;
+						this.model.get("resources")[picsureInstance.id].patientCount = count;
+						this.model.set("totalPatients", this.model.get("totalPatients") + count);
+					}
+
+					this.model.get("resources")[picsureInstance.id].spinning = false;
+					if (_.every(this.model.get("resources"), function (resource) { return resource.spinning === false; })) {
+						this.model.set("spinning", false);
+						this.model.set("queryRan", true);
+					}
+					this.render();
+				}.bind(this);
+
+				queryCache.submitQuery(
+					picsureInstance,
+					query,
+					picsureInstance.id,
+					dataCallback
+				);
+			}.bind(this));
+		},
 		/*
 		 * If you want to show your customized error message, please override this
 		 */
 		outputErrorMessage: undefined,
-		
 		/*
 		 * A function to make any necessary updates to the query before submitting
 		 */

--- a/pic-sure-hpds-ui/src/test/javascript/queryBuilderSpec.js
+++ b/pic-sure-hpds-ui/src/test/javascript/queryBuilderSpec.js
@@ -27,7 +27,7 @@ define(["picSure/queryBuilder", "filter/filter", "jquery"],  function(queryBuild
 					  "expectedResultType": "COUNT"
 					}
 			}
-			expect(queryBuilder.createQuery([new filter.Model({inclusive:true, searchTerm: "Asthma", and: false,theList:null,constrainByValue=true,valueType="STR"})])).toEqual(expectedQuery);
+			expect(queryBuilder.createQuery([new filter.Model({inclusive:true, searchTerm: "Asthma", and: false, theList: null, constrainByValue: true, valueType: "STR"})])).toEqual(expectedQuery);
 		});
 		
 	});

--- a/pic-sure-hpds-ui/src/test/javascript/queryBuilderSpec.js
+++ b/pic-sure-hpds-ui/src/test/javascript/queryBuilderSpec.js
@@ -27,7 +27,7 @@ define(["picSure/queryBuilder", "filter/filter", "jquery"],  function(queryBuild
 					  "expectedResultType": "COUNT"
 					}
 			}
-			expect(queryBuilder.createQuery([new filter.Model({inclusive:true, searchTerm: "Asthma", and: false,theList:null})])).toEqual(expectedQuery);
+			expect(queryBuilder.createQuery([new filter.Model({inclusive:true, searchTerm: "Asthma", and: false,theList:null,constrainByValue=true,valueType="STR"})])).toEqual(expectedQuery);
 		});
 		
 	});

--- a/pic-sure-hpds-ui/src/test/javascript/require_config.txt
+++ b/pic-sure-hpds-ui/src/test/javascript/require_config.txt
@@ -1,6 +1,6 @@
 	baseUrl: "/picsureui",
 	paths: {
-		jquery: '../webjars/jquery/3.4.1/dist/jquery.min',
+		jquery: '../webjars/jquery/3.5.1/dist/jquery.min',
 		autocomplete: '../webjars/devbridge-autocomplete/1.4.7/dist/jquery.autocomplete',
 		underscore: '../webjars/underscorejs/1.8.3/underscore-min',
 		handlebars: '../webjars/handlebars/1.8.3/underscore-min',


### PR DESCRIPTION
This PR adds common area UI. 

Regarding the [acceptance criteria](https://docs.google.com/presentation/d/1EGhtczktCI5qthuvsuFZYbOnolSnbAunMYz2-e8Vbjo/edit#slide=id.g921629788a_3_15): the followings are still in progress:

- Error handling and display of errors
  - [ ] If one node fails then site specific results would show error,
  - [x] but treated as 0 in the roll up of the total results
- Output panel
  - [ ] Add sub-counts for each the sites
  - [ ] Clearing out buttons
  - [ ] If the result is less than 10, then count the result as 0 and show greater than the sum of all counts